### PR TITLE
Call MongoClient#refresh instead of #reconnect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,2 @@
 language: ruby
+script: bundle exec rspec spec

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ logger should be a lambda with two arguments
 
 ```ruby
 logger = lambda { |reason, e|
-  # Where reason may be :retry, :fail, :reconnect_fail
+  # Where reason may be :retry, :fail, :refresh
   p reason
   p e
 }
@@ -50,11 +50,11 @@ doc = retryer.connection_guard {
 }
 # Would be identical have the same effect in respect to the logger as
 logger.call(:retry, exception)
-logger.call(:reconnect_fail, exception)
+logger.call(:refresh, exception)
 logger.call(:retry, exception)
-logger.call(:reconnect_fail, exception)
+logger.call(:refresh, exception)
 logger.call(:retry, exception)
-logger.call(:reconnect_fail, exception)
+logger.call(:refresh, exception)
 logger.call(:fail, exception)
 
 ```

--- a/lib/mongo/retry.rb
+++ b/lib/mongo/retry.rb
@@ -29,7 +29,7 @@ module Mongo
       if retry_timeout = retries.pop
         log(:retry, e)
         @options[:delayer].call(retry_timeout)
-        reconnect!
+        refresh!
         retry
       else
         log(:fail, e)
@@ -45,10 +45,10 @@ module Mongo
       end
     end
 
-    def reconnect!
-      @connection.reconnect
+    def refresh!
+      @connection.refresh
     rescue *@options[:retry_exceptions] => e
-      log(:reconnect_fail, e)
+      log(:refresh, e)
     end
   end
 end

--- a/mongo-retry.gemspec
+++ b/mongo-retry.gemspec
@@ -2,8 +2,6 @@
 
 $: << File.expand_path('../lib', __FILE__)
 
-require 'mongo/retry'
-
 Gem::Specification.new do |s|
   s.name          = 'mongo-retry'
   s.version       = '0.1.2'

--- a/spec/mongo/retry_spec.rb
+++ b/spec/mongo/retry_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 module Mongo
   describe Retry do
-    let(:connection) { double('connection', reconnect: true, do_something: true) }
+    let(:connection) { double('connection', refresh: nil, do_something: true) }
     let(:delayer) { double('delayer', delay: true) }
     let(:logger) { double('logger', log: true)}
 
@@ -55,8 +55,8 @@ module Mongo
           end.to raise_error(error)
         end
 
-        it 'reconnects in case of mongo error' do
-          allow(connection).to receive(:reconnect).and_raise(error)
+        it 'refreshes in case of mongo error' do
+          allow(connection).to receive(:refresh).and_raise(error)
           allow(connection).to receive(:do_something).and_raise(error)
           begin
             subject.connection_guard do
@@ -64,11 +64,11 @@ module Mongo
             end
           rescue error
           end
-          expect(connection).to have_received(:reconnect).exactly(3).times
+          expect(connection).to have_received(:refresh).exactly(3).times
         end
 
-        it 'ignores mongo reconnect errors' do
-          allow(connection).to receive(:reconnect).and_raise(error)
+        it 'ignores mongo refresh errors' do
+          allow(connection).to receive(:refresh).and_raise(error)
           allow(connection).to receive(:do_something).and_raise(error)
           begin
             subject.connection_guard do
@@ -76,11 +76,11 @@ module Mongo
             end
           rescue error
           end
-          expect(connection).to have_received(:reconnect).exactly(3).times
+          expect(connection).to have_received(:refresh).exactly(3).times
         end
 
-        it 'does not rescue non mongo errors when reconnecting' do
-          allow(connection).to receive(:reconnect).and_raise(ArgumentError)
+        it 'does not rescue non mongo errors when refreshing' do
+          allow(connection).to receive(:refresh).and_raise(ArgumentError)
           allow(connection).to receive(:do_something).and_raise(error)
           begin
             subject.connection_guard do
@@ -88,7 +88,7 @@ module Mongo
             end
           rescue ArgumentError
           end
-          expect(connection).to have_received(:reconnect)
+          expect(connection).to have_received(:refresh)
         end
 
         it 'calls sleep in each retry with the correct value' do
@@ -103,7 +103,7 @@ module Mongo
           expect(delayer).to have_received(:delay).once.with(1)
           expect(delayer).to have_received(:delay).once.with(5)
           expect(delayer).to have_received(:delay).once.with(10)
-          expect(connection).to have_received(:reconnect).exactly(3).times
+          expect(connection).to have_received(:refresh).exactly(3).times
         end
 
         it 'logs each connection failure' do
@@ -119,10 +119,10 @@ module Mongo
           expect(logger).to have_received(:log).with(:fail, exception).exactly(:once)
         end
 
-        it 'logs each reconnection failure' do
+        it 'logs each refresh failure' do
           exception = error.new
           allow(connection).to receive(:do_something).and_raise(exception)
-          allow(connection).to receive(:reconnect).and_raise(exception)
+          allow(connection).to receive(:refresh).and_raise(exception)
           begin
             subject.connection_guard do
               connection.do_something
@@ -130,7 +130,7 @@ module Mongo
           rescue error
           end
           expect(logger).to have_received(:log).with(:retry, exception).exactly(3).times
-          expect(logger).to have_received(:log).with(:reconnect_fail, exception).exactly(3).times
+          expect(logger).to have_received(:log).with(:refresh, exception).exactly(3).times
         end
       end
     end


### PR DESCRIPTION
It turns out reconnect is aliased to MongoClient#connect, even for
MongoReplicaSetClient. Obviously, this doesn't work at all, and the
calls to reconnect accomplished nothing, except making sure that we
generated a lot of garbage in the logs. From a cursory look, it also
seems like Mongo actually automatically reconnects when the connection
is lost when doing the common operations, so reconnecting does not seem
to be necessary.

In the end, it turns out refresh is the appropriate thing to do in the
event of a MongoReplicaSetClient. For MongoClient, the operation doesn't
do anything, so calling it should be safe.
