### PR TITLE
v0.3 for the modern mongo driver

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    bson (1.10.2)
+    bson (4.2.1)
     diff-lcs (1.2.5)
-    mongo (1.10.2)
-      bson (= 1.10.2)
+    mongo (2.4.1)
+      bson (>= 4.2.1, < 5.0.0)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
       rspec-expectations (~> 3.1.0)

--- a/mongo-retry.gemspec
+++ b/mongo-retry.gemspec
@@ -4,7 +4,7 @@ $: << File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name          = 'mongo-retry'
-  s.version       = '0.2.0'
+  s.version       = '0.3.0'
   s.authors       = ['Erik Fonselius', 'Sofia Larsson', 'Gustav Munkby']
   s.email         = ['fonsan@burtcorp.com', 'karinsofiapaulina@gmail.com', 'gustav.munkby@burtcorp.com']
   s.homepage      = 'http://github.com/burtcorp/mongo-retry'
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.test_files    = Dir['spec/*.rb']
   s.require_paths = %w(lib)
 
-  s.add_runtime_dependency 'mongo', '~> 1.1'
+  s.add_runtime_dependency 'mongo', '>= 2.2'
 
   s.platform = Gem::Platform::RUBY
   s.required_ruby_version = '>= 1.9.3'

--- a/spec/mongo/retry_spec.rb
+++ b/spec/mongo/retry_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 module Mongo
   describe Retry do
-    let(:connection) { double('connection', refresh: nil, do_something: true) }
+    let(:connection) { double('connection', reconnect: nil, do_something: true) }
     let(:delayer) { double('delayer', delay: true) }
     let(:logger) { double('logger', log: true)}
 
@@ -20,10 +20,9 @@ module Mongo
     end
 
     [
-      ::Mongo::ConnectionError,
-      ::Mongo::ConnectionTimeoutError,
-      ::Mongo::ConnectionFailure,
-      ::Mongo::OperationTimeout
+      ::Mongo::Error::SocketError,
+      ::Mongo::Error::SocketTimeoutError,
+      ::Mongo::Error::NeedPrimaryServer
     ].each do |error|
       describe error.name do
 
@@ -56,7 +55,7 @@ module Mongo
         end
 
         it 'refreshes in case of mongo error' do
-          allow(connection).to receive(:refresh).and_raise(error)
+          allow(connection).to receive(:reconnect).and_raise(error)
           allow(connection).to receive(:do_something).and_raise(error)
           begin
             subject.connection_guard do
@@ -64,11 +63,11 @@ module Mongo
             end
           rescue error
           end
-          expect(connection).to have_received(:refresh).exactly(3).times
+          expect(connection).to have_received(:reconnect).exactly(3).times
         end
 
         it 'ignores mongo refresh errors' do
-          allow(connection).to receive(:refresh).and_raise(error)
+          allow(connection).to receive(:reconnect).and_raise(error)
           allow(connection).to receive(:do_something).and_raise(error)
           begin
             subject.connection_guard do
@@ -76,11 +75,11 @@ module Mongo
             end
           rescue error
           end
-          expect(connection).to have_received(:refresh).exactly(3).times
+          expect(connection).to have_received(:reconnect).exactly(3).times
         end
 
         it 'does not rescue non mongo errors when refreshing' do
-          allow(connection).to receive(:refresh).and_raise(ArgumentError)
+          allow(connection).to receive(:reconnect).and_raise(ArgumentError)
           allow(connection).to receive(:do_something).and_raise(error)
           begin
             subject.connection_guard do
@@ -88,7 +87,7 @@ module Mongo
             end
           rescue ArgumentError
           end
-          expect(connection).to have_received(:refresh)
+          expect(connection).to have_received(:reconnect)
         end
 
         it 'calls sleep in each retry with the correct value' do
@@ -103,7 +102,7 @@ module Mongo
           expect(delayer).to have_received(:delay).once.with(1)
           expect(delayer).to have_received(:delay).once.with(5)
           expect(delayer).to have_received(:delay).once.with(10)
-          expect(connection).to have_received(:refresh).exactly(3).times
+          expect(connection).to have_received(:reconnect).exactly(3).times
         end
 
         it 'logs each connection failure' do
@@ -122,7 +121,7 @@ module Mongo
         it 'logs each refresh failure' do
           exception = error.new
           allow(connection).to receive(:do_something).and_raise(exception)
-          allow(connection).to receive(:refresh).and_raise(exception)
+          allow(connection).to receive(:reconnect).and_raise(exception)
           begin
             subject.connection_guard do
               connection.do_something
@@ -130,7 +129,7 @@ module Mongo
           rescue error
           end
           expect(logger).to have_received(:log).with(:retry, exception).exactly(3).times
-          expect(logger).to have_received(:log).with(:refresh, exception).exactly(3).times
+          expect(logger).to have_received(:log).with(:reconnect, exception).exactly(3).times
         end
       end
     end


### PR DESCRIPTION
This pull request moves to the new mongo driver, versions 2.2 and upward. No attempt at backwards compatibility has been made. The major change is that all errors have changed namespace, and that `refresh` has been removed and we are now back to using `reconnect!`.